### PR TITLE
set encoding to avoid syntax error

### DIFF
--- a/MarkdownHtmlPreview.py
+++ b/MarkdownHtmlPreview.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import sublime
 import sublime_plugin


### PR DESCRIPTION
Hello.
I hope this is helpful.
I know Sublime Text 2 is no longer supported but I had a need for this package and this seems like a trivial fix.

I was getting error: SyntaxError: Non-ASCII character '\xc2' in file ./MarkdownHtmlPreview.py on line 36, but no encoding declared; in Sublime Text 2 console until I added the encoding statement.

My Env:
MacOS 10.14.6
